### PR TITLE
Added pageFormat to handle response of many

### DIFF
--- a/src/ra-data-spring-rest.js
+++ b/src/ra-data-spring-rest.js
@@ -58,6 +58,7 @@ export default (apiUrl, httpClient = fetch) => {
             case GET_MANY:
                 options.method = 'GET';
                 options.params = {id: params.ids};
+                format = pageFormat;
                 break;
             case GET_MANY_REFERENCE:
                 options.method = 'GET';


### PR DESCRIPTION
While get request for many items is send, response is handled on level of pageable object not content of it.